### PR TITLE
Replacing `title` and `url` with the entire entry model

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,11 @@ The `craft.weightedSearch.substringSearch` function takes a search string as a
 parameter and returns an array of results that is sorted from most relevant to
 least relevant.
 
-Each result has these fields: `url`, `title`, `excerpt` and `score`. The
+Each result has these fields: `entry`, `excerpt` and `score`. The
 excerpt is in HTML format, where each instance of the search string has been
 marked up with the `mark` element.
+
+You can leverage `entry` as you would any other [ElementCriteriaModel](https://craftcms.com/docs/templating/elementcriteriamodel) (eg. `{{searchresult.entry.title}}`).  
 
 Example template code:
 
@@ -33,7 +35,8 @@ Example template code:
      <ul>
          {% for searchResult in results %}
              <li>
-                 <a href="{{ searchResult.url }}">{{ searchResult.title }}</a>
+                 <a href="{{ searchResult.entry.url }}">{{ searchResult.entry.title }}</a>
+                 <img src="{{searchResult.entry.thumbnail.first().url" alt="{{searchResult.entry.thumbnailAltText}}">
                  <p>{{ searchResult.excerpt|raw }}</p>
                  <!-- Score: {{ searchResult.score }} -->
              </li>

--- a/weightedsearch/services/WeightedSearch_EntriesService.php
+++ b/weightedsearch/services/WeightedSearch_EntriesService.php
@@ -73,8 +73,7 @@ class WeightedSearch_EntriesService extends BaseApplicationComponent
                     $overrideWeight =
                             $this->getOverrideWeight($viewableEntry, $needle);
                     $result[$viewableId] = array(
-                        'title' => $viewableEntry->title,
-                        'url' => $viewableEntry->url,
+                        'entry' => $viewableEntry,
                         'excerpt' => '',
                         'score' => ($overrideWeight + $weight),
                     );

--- a/weightedsearch/services/WeightedSearch_EntriesService.php
+++ b/weightedsearch/services/WeightedSearch_EntriesService.php
@@ -36,8 +36,8 @@ class WeightedSearch_EntriesService extends BaseApplicationComponent
      * @return array The search results, with the most relevant results first.
      *         Each item in the array is itself an array, with the following
      *         keys:
-     *         'title': (string) Title field of the entry
-     *         'url': (string) URL of the entry
+     *         'entry': (object) Craft ElementCriteriaModel of entry returned 
+     *                    in the search result
      *         'excerpt': (string) Where the needle was found as part of a
      *                    larger string of text (e.g. a rich text field), this
      *                    will show an example of the needle in context,


### PR DESCRIPTION
Opening up a pull request for: #2 (Expose entire EntryModel instead of just Title and URL)

This pull request would allow developers to access more fields than just the title and URL in the search results variable.  
