### PR TITLE
Unclosed braces in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Example template code:
          {% for searchResult in results %}
              <li>
                  <a href="{{ searchResult.entry.url }}">{{ searchResult.entry.title }}</a>
-                 <img src="{{searchResult.entry.thumbnail.first().url" alt="{{searchResult.entry.thumbnailAltText}}">
+                 <img src="{{searchResult.entry.thumbnail.first().url}}" alt="{{searchResult.entry.thumbnailAltText}}">
                  <p>{{ searchResult.excerpt|raw }}</p>
                  <!-- Score: {{ searchResult.score }} -->
              </li>


### PR DESCRIPTION
Braces in the example code has an unclosed brace `{{searchResult.entry.thumbnail.first().url` which causes the example code to throw an error. Craft does not give a clear error warning that this is the case and therefore is confusing for those who are new to Craft and/or this plugin.